### PR TITLE
Added option to enable digest authentication for rtorrent users

### DIFF
--- a/app.py
+++ b/app.py
@@ -882,6 +882,7 @@ FALLBACK_CONFIG = {
     "TORRENT_CLIENT_USERNAME": "admin",
     "TORRENT_CLIENT_PASSWORD": "",
     "TORRENT_CLIENT_CATEGORY": "",
+    "RTORRENT_DIGEST_AUTH": False,
     "MAM_ID": "",
     "DATA_PATH": "./data",
     "ORGANIZED_PATH": "/downloads/organized",
@@ -1116,7 +1117,8 @@ def load_config():
         "AUTO_BUY_UPLOAD_ON_BONUS",
         "BLOCK_DOWNLOAD_ON_LOW_BUFFER",
         "AUTO_BUY_PERSONAL_FL_ON_DOWNLOAD",
-        "ENABLE_FILESYSTEM_THUMBNAIL_CACHE"
+        "ENABLE_FILESYSTEM_THUMBNAIL_CACHE",
+        "RTORRENT_DIGEST_AUTH"
     ]:
         config[key] = coerce_bool(config.get(key), FALLBACK_CONFIG[key])
         val = config[key]

--- a/clients/rtorrent.py
+++ b/clients/rtorrent.py
@@ -13,6 +13,7 @@ class RTorrentClient(TorrentClient):
         self.url = config.get("TORRENT_CLIENT_URL", "http://localhost/RPC2")
         self.username = config.get("TORRENT_CLIENT_USERNAME", "")
         self.password = config.get("TORRENT_CLIENT_PASSWORD", "")
+        self.digest_auth = config.get("RTORRENT_DIGEST_AUTH", False)
         
         # Standard ruTorrent label field is usually d.custom1
         self.label_attr = "d.custom1" 
@@ -46,7 +47,10 @@ class RTorrentClient(TorrentClient):
 </methodCall>"""
 
         headers = {"Content-Type": "text/xml"}
-        auth = (self.username, self.password) if self.username else None
+        if self.digest_auth:
+            auth = httpx.DigestAuth(self.username, self.password) if self.username else None
+        else:
+            auth = (self.username, self.password) if self.username else None
 
         try:
             # verify=False handles self-signed certs often found on seedboxes


### PR DESCRIPTION
So I will be upfront and say that I haven't touched the UI components as yet, but my seedbox provider has used Digest auth instead of basic auth, which means I won't be able to authenticate with rutorrent as-is.

Accordingly I added a new boolean env RTORRENT_DIGEST_AUTH.

When true it instantiates httpx.DigestAuth with the supplied credentials to allow authenticating to rutorrent using digest auth instead of basic auth. Default for the bool is False.

If you'd prefer, I'm happy to spend the time updating the UI code as well, though I do worry that I might not quite hit the style you're going for.