### PR TITLE
Add support for serving the app under a URL prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,38 @@ The application will be available at `http://<your-server-ip>:5000`.
 
 The application will be available at `http://<your-server-ip>:5000` (or your custom port).
 
+### Serving Under a URL Prefix (Reverse Proxy Subpath)
+
+By default the application is served from the root of its host (`http://<your-server-ip>:5000`). If you want to serve it under a subpath behind a reverse proxy (e.g., `https://<your-domain>/mousesearch/`, common on shared seedboxes), launch it with `--root-path`:
+
+```bash
+./launch.sh --port 8080 --root-path /mousesearch
+```
+
+You can also set `ROOT_PATH=/mousesearch` in `.env` instead of passing the flag. When running behind a reverse proxy on the same machine, add `--bind 127.0.0.1` so the app is only reachable through the proxy.
+
+Then point your reverse proxy at the app **without stripping the prefix** — the app removes it itself via the ASGI `root_path` mechanism. Example Nginx location:
+
+```nginx
+location /mousesearch/ {
+    proxy_pass          http://127.0.0.1:8080;   # no trailing slash: keep the prefix
+    proxy_http_version  1.1;
+    proxy_set_header    Host                $http_host;
+    proxy_set_header    X-Forwarded-Proto   $scheme;
+    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+
+    # Required for live status updates (Server-Sent Events)
+    proxy_buffering     off;
+    proxy_read_timeout  1h;
+}
+```
+
+Notes:
+
+* The prefix must not have a trailing slash (`/mousesearch`, not `/mousesearch/`).
+* Without `--root-path`, nothing changes — the app behaves exactly as before.
+* `proxy_buffering off` and the long `proxy_read_timeout` matter: MouseSearch streams live torrent status over Server-Sent Events (`/events`), which stalls behind a buffering proxy and is cut off by Nginx's default 60-second read timeout.
+
 ---
 
 ## Configuration

--- a/launch.sh
+++ b/launch.sh
@@ -17,6 +17,8 @@ fi
 # Default values
 VENV_PATH="${VENV_PATH:-.venv}"
 PORT="${PORT:-5000}"
+BIND_ADDRESS="${BIND_ADDRESS:-0.0.0.0}"
+ROOT_PATH="${ROOT_PATH:-}"
 ACCESS_LOGFILE="${ACCESS_LOGFILE:-/dev/null}"
 
 # Parse command line arguments
@@ -34,12 +36,22 @@ while [[ $# -gt 0 ]]; do
             ACCESS_LOGFILE="$2"
             shift 2
             ;;
+        -b|--bind)
+            BIND_ADDRESS="$2"
+            shift 2
+            ;;
+        -r|--root-path)
+            ROOT_PATH="$2"
+            shift 2
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
             echo "  -p, --port PORT       Set the port (default: 5000)"
             echo "  -v, --venv PATH       Set the virtual environment path (default: .venv)"
             echo "  -a, --access-logfile  Hypercorn access log target (default: /dev/null, use '-' for stdout)"
+            echo "  -b, --bind ADDRESS    Bind address (default: 0.0.0.0, use 127.0.0.1 behind a reverse proxy)"
+            echo "  -r, --root-path PATH  Serve the app under a URL prefix, e.g. /mousesearch (default: none)"
             echo "  -h, --help            Show this help message"
             exit 0
             ;;
@@ -60,7 +72,12 @@ fi
 source "$VENV_PATH/bin/activate"
 
 # Launch hypercorn with specified port
-hypercorn --bind "0.0.0.0:$PORT" --workers 1 --worker-class asyncio --access-logfile "$ACCESS_LOGFILE" --error-logfile - --log-level info app:app 2>&1 | while IFS= read -r line; do
+EXTRA_ARGS=()
+if [ -n "$ROOT_PATH" ]; then
+    EXTRA_ARGS+=(--root-path "$ROOT_PATH")
+fi
+
+hypercorn --bind "$BIND_ADDRESS:$PORT" --workers 1 --worker-class asyncio --access-logfile "$ACCESS_LOGFILE" --error-logfile - --log-level info "${EXTRA_ARGS[@]}" app:app 2>&1 | while IFS= read -r line; do
     echo "$line"
     if [[ "$line" == *"Address already in use"* ]] || [[ "$line" == *"Errno 98"* ]]; then
         echo ""

--- a/static/favicon/manifest.json
+++ b/static/favicon/manifest.json
@@ -3,13 +3,13 @@
   "short_name": "Mouse",
   "icons": [
     {
-      "src": "/static/favicon/web-app-manifest-192x192.png",
+      "src": "web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/static/favicon/web-app-manifest-512x512.png",
+      "src": "web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
@@ -18,5 +18,5 @@
   "theme_color": "#aa7df3",
   "background_color": "#ffffff",
   "display": "standalone",
-  "start_url": "/"
+  "start_url": "../../"
 }

--- a/static/favicon/site.webmanifest
+++ b/static/favicon/site.webmanifest
@@ -3,13 +3,13 @@
   "short_name": "Mouse",
   "icons": [
     {
-      "src": "/static/favicon/web-app-manifest-192x192.png",
+      "src": "web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/static/favicon/web-app-manifest-512x512.png",
+      "src": "web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
@@ -18,5 +18,5 @@
   "theme_color": "#ffffff",
   "background_color": "#ffffff",
   "display": "standalone",
-  "start_url": "/"
+  "start_url": "../../"
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,9 +4,13 @@
 //  1. GLOBAL HELPERS & STATE
 // ============================================================
 
+// Base path support: set by the inline shim in index.html when the app is
+// served under a URL prefix (hypercorn --root-path). Empty string at root.
+const APP_BASE = (window.APP_BASE || '').replace(/\/+$/, '');
+
 // Icon definitions
-const greenCheckIcon = `<img src="/static/icons/check_circle.svg" alt="connected" style="height: 16px; width: 16px;">`;
-const redXIcon = `<img src="/static/icons/x_circle.svg" alt="not connected" style="height: 16px; width: 16px;">`;
+const greenCheckIcon = `<img src="${APP_BASE}/static/icons/check_circle.svg" alt="connected" style="height: 16px; width: 16px;">`;
+const redXIcon = `<img src="${APP_BASE}/static/icons/x_circle.svg" alt="not connected" style="height: 16px; width: 16px;">`;
 
 // Global State
 const torrentHashMap = {};
@@ -41,8 +45,8 @@ window.__hardcoverPendingStatusBookIds = hardcoverPendingStatusBookIds;
 const pendingHardcoverEnrichmentPayloads = window.__pendingHardcoverEnrichmentPayloads instanceof Map ? window.__pendingHardcoverEnrichmentPayloads : new Map();
 window.__pendingHardcoverEnrichmentPayloads = pendingHardcoverEnrichmentPayloads;
 let hardcoverStatusPickerOpenedAt = 0;
-const MOUSESEARCH_LOGO_URL = '/static/icons/mouse.svg';
-const HARDCOVER_LOGO_URL = '/static/icons/hardcover.png';
+const MOUSESEARCH_LOGO_URL = `${APP_BASE}/static/icons/mouse.svg`;
+const HARDCOVER_LOGO_URL = `${APP_BASE}/static/icons/hardcover.png`;
 const HARDCOVER_STATUS_DEFINITIONS = Object.freeze([
     {
         statusId: 1,
@@ -201,7 +205,7 @@ function loadLegacyCategoryDefinitions() {
     if (legacyCategoryData) return Promise.resolve(legacyCategoryData);
     if (legacyCategoryPromise) return legacyCategoryPromise;
 
-    const legacyUrl = window.LEGACY_CATEGORY_URL || '/static/categoryDefinitionsLegacy.json';
+    const legacyUrl = window.LEGACY_CATEGORY_URL || `${APP_BASE}/static/categoryDefinitionsLegacy.json`;
     legacyCategoryPromise = fetch(legacyUrl, { cache: 'no-store' })
         .then(response => {
             if (!response.ok) throw new Error('Failed to load legacy categories');
@@ -297,7 +301,7 @@ function getPosterExtension(mimeType) {
 function handleBookCoverError(imgElement) {
     // 1. Prevent infinite loop if placeholder is also missing
     imgElement.onerror = null;
-    imgElement.src = '/static/icons/no_cover.png';
+    imgElement.src = `${APP_BASE}/static/icons/no_cover.png`;
 
     // 2. Set a fallback background for the hero
     // (Blurring the "no_cover.png" usually looks bad, so we use a gradient instead)
@@ -488,12 +492,12 @@ function handleResultThumbnailError(imgElement) {
     if (hardcoverCoverUrl && imgElement.dataset.triedHardcoverCover !== 'true') {
         imgElement.dataset.triedHardcoverCover = 'true';
         if (resultItem) resultItem.dataset.hasMamCover = 'false';
-        imgElement.src = `/proxy_thumbnail?url=${encodeURIComponent(hardcoverCoverUrl)}`;
+        imgElement.src = `${APP_BASE}/proxy_thumbnail?url=${encodeURIComponent(hardcoverCoverUrl)}`;
         return;
     }
 
     imgElement.onerror = null;
-    imgElement.src = '/static/icons/no_cover.png';
+    imgElement.src = `${APP_BASE}/static/icons/no_cover.png`;
 }
 
 window.handleResultThumbnailError = handleResultThumbnailError;
@@ -1266,7 +1270,7 @@ function renderHardcoverSeriesStrip(series, currentBookId, currentPosition) {
         const hardcoverUrl = hardcoverBookLink(slug);
         const mouseSearchUrl = buildMouseSearchUrlForTitle(title);
         const coverUrl = String(book.image_url || '').trim();
-        const proxyCoverUrl = coverUrl ? `/proxy_thumbnail?url=${encodeURIComponent(coverUrl)}` : '/static/icons/no_cover.png';
+        const proxyCoverUrl = coverUrl ? `${APP_BASE}/proxy_thumbnail?url=${encodeURIComponent(coverUrl)}` : `${APP_BASE}/static/icons/no_cover.png`;
         const positionLabel = formatHardcoverSeriesPosition(entry?.position);
         const releaseYear = String(book.release_year || '').trim();
         const isCurrent = currentBookKey && bookId === currentBookKey;
@@ -1331,7 +1335,7 @@ async function loadHardcoverSeriesStrip(metadata) {
     if (section) section.classList.remove('d-none');
 
     try {
-        const response = await fetch(`/hardcover/series/${encodeURIComponent(String(seriesId))}`);
+        const response = await fetch(`${APP_BASE}/hardcover/series/${encodeURIComponent(String(seriesId))}`);
         if (!response.ok) {
             throw new Error(`Hardcover series HTTP ${response.status}`);
         }
@@ -1592,7 +1596,7 @@ function applyHardcoverEnrichmentUpdate(payload) {
         const thumb = resultItem.querySelector('.results-thumb');
         if (thumb) {
             thumb.dataset.triedHardcoverCover = 'true';
-            thumb.src = `/proxy_thumbnail?url=${encodeURIComponent(coverUrl)}`;
+            thumb.src = `${APP_BASE}/proxy_thumbnail?url=${encodeURIComponent(coverUrl)}`;
         }
     }
 
@@ -1654,7 +1658,7 @@ function stopHardcoverEnrichmentPolling() {
 
 async function pollHardcoverEnrichment(searchId) {
     try {
-        const response = await fetch(`/hardcover/enrichment/${encodeURIComponent(searchId)}`, {
+        const response = await fetch(`${APP_BASE}/hardcover/enrichment/${encodeURIComponent(searchId)}`, {
             cache: 'no-store'
         });
         if (!response.ok) throw new Error(`Hardcover poll HTTP ${response.status}`);
@@ -1741,7 +1745,7 @@ async function queueHardcoverEnrichmentRows(searchId, rows) {
     const queueRequest = previousRequest
         .catch(() => undefined)
         .then(async () => {
-            const response = await fetch(`/hardcover/enrichment/${encodeURIComponent(searchId)}/queue`, {
+            const response = await fetch(`${APP_BASE}/hardcover/enrichment/${encodeURIComponent(searchId)}/queue`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ torrent_ids: torrentIds }),
@@ -1957,7 +1961,7 @@ function formatPrimarySeriesLabel(primarySeries) {
  * Initializes Server-Sent Events (SSE)
  */
 function initializeEventStream() {
-    const eventSource = new EventSource('/events');
+    const eventSource = new EventSource(`${APP_BASE}/events`);
 
     eventSource.onmessage = function (event) {
         try {
@@ -2128,7 +2132,7 @@ function renderJsonTree(data, containerId) {
 async function getTorrentHashByMID(torrentId) {
     if (torrentHashMap[torrentId]) return torrentHashMap[torrentId];
     try {
-        const response = await fetch('/client/resolve_mid', {
+        const response = await fetch(`${APP_BASE}/client/resolve_mid`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ mid: torrentId })
@@ -2346,7 +2350,7 @@ function checkClientStatus() {
     const statusIconSpan = document.getElementById("client-status-icon");
     const clientTypeDisplay = document.getElementById('client-type-display');
 
-    fetch('/client/status', { cache: "no-store" })
+    fetch(`${APP_BASE}/client/status`, { cache: "no-store" })
         .then(response => response.json())
         .then(data => {
             const isSuccess = data.status === "success";
@@ -2387,7 +2391,7 @@ function checkClientStatus() {
 }
 
 function refreshCategories() {
-    fetch('/client/categories', { cache: "no-store" })
+    fetch(`${APP_BASE}/client/categories`, { cache: "no-store" })
         .then(response => response.json())
         .then(data => {
             const resultDropdowns = document.querySelectorAll('.category-dropdown');
@@ -2470,7 +2474,7 @@ function hideMamNotConfiguredPrompt() {
 }
 
 function loadMamUserData() {
-    fetch('/mam/user_data', { cache: "no-store" })
+    fetch(`${APP_BASE}/mam/user_data`, { cache: "no-store" })
         .then(async response => {
             const data = await response.json().catch(() => ({}));
             updateMamProxyStatusPanel(data?.proxy_status);
@@ -2625,7 +2629,7 @@ function initializeSnatchedTorrents() {
 
 async function fetchAndUpdateTorrentStatus(hash, resultItem) {
     try {
-        const response = await fetch(`/client/info/${hash}`, { cache: "no-store" });
+        const response = await fetch(`${APP_BASE}/client/info/${hash}`, { cache: "no-store" });
         if (response.ok) {
             const data = await response.json();
             updateTorrentUI(hash, data, resultItem);
@@ -2849,8 +2853,8 @@ function updateMamProxyStatusPanel(proxyStatus) {
 
 async function fetchPublicIP() {
     Promise.allSettled([
-        fetch('/system/public_ip?route=direct').then(r => r.json()),
-        fetch('/system/public_ip?route=mam').then(r => r.json()),
+        fetch(`${APP_BASE}/system/public_ip?route=direct`).then(r => r.json()),
+        fetch(`${APP_BASE}/system/public_ip?route=mam`).then(r => r.json()),
     ])
         .then(([directResult, proxyResult]) => {
             const directData = directResult.status === 'fulfilled' ? directResult.value : null;
@@ -3046,7 +3050,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         setHardcoverStatusPickerBusy(picker, true);
 
         try {
-            const response = await fetch(`/hardcover/user-book/${bookId}`, { cache: 'no-store' });
+            const response = await fetch(`${APP_BASE}/hardcover/user-book/${bookId}`, { cache: 'no-store' });
             const data = await response.json().catch(() => ({}));
             if (!response.ok || data.status !== 'success') {
                 throw new Error(data.message || `Hardcover status lookup failed (HTTP ${response.status})`);
@@ -3078,7 +3082,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         closeHardcoverStatusPickers();
         setHardcoverStatusPending(bookId, true);
         try {
-            const response = await fetch('/hardcover/user-book/status', {
+            const response = await fetch(`${APP_BASE}/hardcover/user-book/status`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -3309,7 +3313,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         });
 
         try {
-            const response = await fetch('/api/settings/test-torrent-client', {
+            const response = await fetch(`${APP_BASE}/api/settings/test-torrent-client`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),
@@ -3361,7 +3365,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         });
 
         try {
-            const response = await fetch('/api/settings/test-hardcover', {
+            const response = await fetch(`${APP_BASE}/api/settings/test-hardcover`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),
@@ -3670,7 +3674,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     // Save Settings
     document.getElementById('save-settings-button')?.addEventListener('click', function () {
         triggerHaptic('save');
-        fetch('/update_settings', { method: 'POST', body: new FormData(document.getElementById('settings-form')) })
+        fetch(`${APP_BASE}/update_settings`, { method: 'POST', body: new FormData(document.getElementById('settings-form')) })
             .then(response => response.json())
             .then(data => {
                 showToast(data.message, data.status === 'success' ? 'success' : 'danger');
@@ -3706,7 +3710,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         setInlineActionStatus('organize-now-status', 'idle', 'Running one-time organization pass...');
 
         try {
-            const response = await fetch('/organize', { method: 'POST' });
+            const response = await fetch(`${APP_BASE}/organize`, { method: 'POST' });
             const data = await response.json().catch(() => ({}));
             const results = data?.results || {};
             const succeeded = Number(results.succeeded || 0);
@@ -3813,7 +3817,7 @@ document.addEventListener("DOMContentLoaded", async function () {
                 this.innerHTML = `<div class="d-flex align-items-center"><span class="spinner-border spinner-border-sm me-2"></span> Processing...</div>`;
                 document.querySelectorAll('.vip-buy-btn').forEach(b => b.classList.add('disabled'));
 
-                fetch('/mam/buy_vip', {
+                fetch(`${APP_BASE}/mam/buy_vip`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ duration: duration })
@@ -3849,7 +3853,7 @@ document.addEventListener("DOMContentLoaded", async function () {
             this.disabled = true;
             this.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> Buying...';
 
-            fetch('/mam/buy_wedge', {
+            fetch(`${APP_BASE}/mam/buy_wedge`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' }
             })
@@ -3879,7 +3883,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     function submitUploadPurchase(amount, onBefore, onAfter) {
         if (typeof onBefore === 'function') onBefore();
-        fetch('/mam/buy_upload', {
+        fetch(`${APP_BASE}/mam/buy_upload`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ amount })
@@ -5391,7 +5395,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
         try {
             const payload = { filters: collectCurrentSearchFilterDefaults() };
-            const response = await fetch('/update_default_search_filters', {
+            const response = await fetch(`${APP_BASE}/update_default_search_filters`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)
@@ -5454,7 +5458,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     function saveResultDisplayFields(fields) {
-        return fetch('/update_result_display_fields', {
+        return fetch(`${APP_BASE}/update_result_display_fields`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ fields })
@@ -6013,7 +6017,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
             let info = null;
             try {
-                const response = await fetch(`/client/info/${hash}`, { cache: 'no-store' });
+                const response = await fetch(`${APP_BASE}/client/info/${hash}`, { cache: 'no-store' });
                 if (response.ok) info = await response.json();
             } catch (_) {
                 // If info fails, still treat as in-client; we just won't know complete vs downloading.
@@ -6219,7 +6223,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         }
         hashToElementMap.clear();
         stopHardcoverEnrichmentPolling();
-        const searchUrl = queryString ? `/mam/search?${queryString}` : '/mam/search';
+        const searchUrl = queryString ? `${APP_BASE}/mam/search?${queryString}` : `${APP_BASE}/mam/search`;
 
         if (preScrollToResults && wrapper) {
             wrapper.style.display = 'block';
@@ -6768,8 +6772,8 @@ document.addEventListener("DOMContentLoaded", async function () {
         const lowResUrl = `https://cdn.myanonamouse.net/t/p/small/${data.id}.webp`;
 
         // 2. Prepare Proxy URLs
-        const highResProxy = `/proxy_thumbnail?url=${encodeURIComponent(highResUrl)}`;
-        const lowResProxy = `/proxy_thumbnail?url=${encodeURIComponent(lowResUrl)}`;
+        const highResProxy = `${APP_BASE}/proxy_thumbnail?url=${encodeURIComponent(highResUrl)}`;
+        const lowResProxy = `${APP_BASE}/proxy_thumbnail?url=${encodeURIComponent(lowResUrl)}`;
 
         // Push History State
         const newUrl = window.location.pathname + window.location.search + `#book=${data.id}`;
@@ -6798,8 +6802,8 @@ document.addEventListener("DOMContentLoaded", async function () {
             const ext = getPosterExtension(data.poster_type);
             const rawHi = `https://cdn.myanonamouse.net/t/p/0/large/${data.id}.${ext}`;
             const rawLow = `https://cdn.myanonamouse.net/t/p/small/${data.id}.webp`;
-            hiResSrc = `/proxy_thumbnail?url=${encodeURIComponent(rawHi)}`;
-            lowResSrc = `/proxy_thumbnail?url=${encodeURIComponent(rawLow)}`;
+            hiResSrc = `${APP_BASE}/proxy_thumbnail?url=${encodeURIComponent(rawHi)}`;
+            lowResSrc = `${APP_BASE}/proxy_thumbnail?url=${encodeURIComponent(rawLow)}`;
         }
 
         // --- Standard Metadata Rendering ---
@@ -6913,7 +6917,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
         // 3. Attach Error Handler — try Hardcover cover before falling back to placeholder
         const hcCoverProxy = data.hardcover_enrichment?.hardcover?.cover_image
-            ? `/proxy_thumbnail?url=${encodeURIComponent(data.hardcover_enrichment.hardcover.cover_image)}`
+            ? `${APP_BASE}/proxy_thumbnail?url=${encodeURIComponent(data.hardcover_enrichment.hardcover.cover_image)}`
             : null;
         activeImgEl.onerror = function () {
             if (hcCoverProxy && !this.dataset.triedHardcoverCover) {
@@ -7079,7 +7083,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     function performDownload(downloadData, button) {
         if (button) button.disabled = true;
 
-        fetch('/client/add', {
+        fetch(`${APP_BASE}/client/add`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(downloadData),
@@ -7189,7 +7193,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         const amount = parseFloat(this.dataset.amount);
         this.disabled = true;
         this.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Buying...';
-        fetch('/mam/buy_upload', {
+        fetch(`${APP_BASE}/mam/buy_upload`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ amount: amount })
@@ -7608,7 +7612,7 @@ function initAutosuggest(inputId) {
         cacheProbeController = new AbortController();
 
         try {
-            const res = await fetch(`/mam/autosuggest?${queryString}&cache_only=true`, {
+            const res = await fetch(`${APP_BASE}/mam/autosuggest?${queryString}&cache_only=true`, {
                 signal: cacheProbeController.signal
             });
             if (!res.ok) return;
@@ -7689,7 +7693,7 @@ function initAutosuggest(inputId) {
             }
             hasIssuedInitialSearch = true;
 
-            const res = await fetch(`/mam/autosuggest?${queryString}`, {
+            const res = await fetch(`${APP_BASE}/mam/autosuggest?${queryString}`, {
                 signal: abortController.signal
             });
             if (!res.ok) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,7 @@
 <head>
   <script src="{{ url_for('static', filename='bootstrap/js/color-modes.js') }}"></script>
   <script>
+    window.APP_BASE = {{ request.root_path | tojson }};
     window.LANGUAGE_MAP = {{ LANGUAGE_MAP | tojson }};
     window.DEFAULT_LANGUAGE_ID = {{ DEFAULT_LANGUAGE_ID | tojson }};
     window.DEFAULT_SEARCH_FILTERS = {{ SEARCH_FILTER_DEFAULTS | tojson }};
@@ -152,7 +153,7 @@
 
   <main class="container px-0">
     <div class="d-flex justify-content-center align-items-center p-3 my-sm-3 text-white bg-purple rounded-sm shadow-sm">
-      <a href="/" class="lh-1 text-center text-decoration-none">
+      <a href="{{ url_for('index') }}" class="lh-1 text-center text-decoration-none">
         <span class="app-logo d-inline-block align-middle" role="img" aria-label="Logo" style="width:60px;height:60px;"></span>
         <h1 class="h1 mb-0 text-white lh-1">MouseSearch</h1>
       </a>
@@ -499,12 +500,12 @@
   {% include 'modals/insufficient_buffer.html' %}
   {% include 'modals/book_details.html' %}
 
-  <script src="static/bootstrap/js/bootstrap.bundle.min.js">import "bootstrap";</script>
+  <script src="{{ url_for('static', filename='bootstrap/js/bootstrap.bundle.min.js') }}">import "bootstrap";</script>
   <script src="https://cdn.jsdelivr.net/npm/tom-select@2.4.5/dist/js/tom-select.complete.min.js"></script>
   <script>
     window.resultDisplayFields = {{ RESULTS_DISPLAY_FIELDS | tojson }};
   </script>
-  <script src="static/js/main.js"></script>
+  <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 
 
   <div id="toast-container" aria-live="polite" aria-atomic="true" class="position-fixed bottom-0 end-0 p-3"

--- a/templates/modals/book_details.html
+++ b/templates/modals/book_details.html
@@ -21,7 +21,7 @@
               <div
                 class="col-12 col-md-4 col-lg-4 mb-4 mb-md-0 text-center text-md-start d-flex justify-content-center align-items-center">
                 <div class="book-cover-wrapper">
-                  <img src="/static/icons/no_cover.png" id="detail-cover" class="book-cover-img" alt="Cover">
+                  <img src="{{ url_for('static', filename='icons/no_cover.png') }}" id="detail-cover" class="book-cover-img" alt="Cover">
                 </div>
               </div>
 
@@ -43,7 +43,7 @@
                       <a id="detail-hero-hc-link-main" class="detail-hero-hc-card__link d-inline-flex flex-column gap-1 text-decoration-none"
                         href="#" target="_blank" rel="noopener noreferrer">
                         <div class="d-flex align-items-center gap-1 opacity-75" style="font-size: 0.7rem;">
-                          <img src="/static/icons/hardcover.png" alt="" style="width: 0.8rem; height: 0.8rem; object-fit: contain;" loading="lazy">
+                          <img src="{{ url_for('static', filename='icons/hardcover.png') }}" alt="" style="width: 0.8rem; height: 0.8rem; object-fit: contain;" loading="lazy">
                           <span class="text-uppercase fw-semibold" style="letter-spacing: 0.05em;">Hardcover</span>
                         </div>
                         <div id="detail-hero-hc-rating" class="d-none"></div>
@@ -173,7 +173,7 @@
 
                 <div class="card mb-4" id="detail-hardcover-card" style="display: none;">
                   <div class="card-header d-flex align-items-center gap-2">
-                    <img src="/static/icons/hardcover.png" alt="" style="width: 1rem; height: 1rem; object-fit: contain;" loading="lazy">
+                    <img src="{{ url_for('static', filename='icons/hardcover.png') }}" alt="" style="width: 1rem; height: 1rem; object-fit: contain;" loading="lazy">
                     <h5 class="my-2 text-body-emphasis">Hardcover</h5>
                   </div>
                   <div class="card-body">

--- a/templates/modals/settings_offcanvas.html
+++ b/templates/modals/settings_offcanvas.html
@@ -33,7 +33,7 @@
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="hardcover-tab" data-bs-toggle="tab" data-bs-target="#hardcover-pane"
               type="button" role="tab" aria-controls="hardcover-pane" aria-selected="false">
-              <img src="/static/icons/hardcover.png" alt="" class="settings-menu-icon me-1" loading="lazy">
+              <img src="{{ url_for('static', filename='icons/hardcover.png') }}" alt="" class="settings-menu-icon me-1" loading="lazy">
               Hardcover
             </button>
           </li>
@@ -544,7 +544,7 @@
               class="card-header border-bottom-0 bg-transparent d-flex justify-content-between align-items-center py-2 cursor-pointer noselect"
               onclick="toggleCardSwitch('HARDCOVER_ENRICHMENT_ENABLED')">
               <span class="small fw-bold d-flex align-items-center">
-                <img src="/static/icons/hardcover.png" alt="" class="settings-inline-logo me-2" loading="lazy">
+                <img src="{{ url_for('static', filename='icons/hardcover.png') }}" alt="" class="settings-inline-logo me-2" loading="lazy">
                 Enable Hardcover Metadata Enrichment
               </span>
               <div class="form-check form-switch m-0">

--- a/templates/partials/results.html
+++ b/templates/partials/results.html
@@ -96,7 +96,7 @@
             <div class="hardcover-enrichment small mt-2 mb-2" data-hardcover-container>
                 <div class="hardcover-match hardcover-match--pending d-flex flex-column gap-1 text-decoration-none pe-none">
                     <div class="d-flex align-items-center gap-1 text-body-secondary" style="font-size: 0.7rem;">
-                        <img src="/static/icons/hardcover.png" alt="" style="width: 0.8rem; height: 0.8rem; object-fit: contain;" loading="lazy">
+                        <img src="{{ url_for('static', filename='icons/hardcover.png') }}" alt="" style="width: 0.8rem; height: 0.8rem; object-fit: contain;" loading="lazy">
                         <span class="text-uppercase fw-semibold" style="letter-spacing: 0.05em;">Hardcover</span>
                     </div>
                     <div class="d-flex align-items-center gap-1" style="font-size: 0.8rem;">


### PR DESCRIPTION
## What

Adds support for serving MouseSearch under a URL prefix (e.g. `https://example.com/mousesearch/`) behind a reverse proxy, instead of only at the root of a host.

## Why

On shared hosts (seedboxes, home servers behind a single nginx, etc.) apps are commonly exposed as subpaths of one domain rather than on dedicated ports. MouseSearch currently can't run this way: the frontend hardcodes root-absolute URLs (`fetch('/client/status')`, `new EventSource('/events')`, `/static/...` assets, `/proxy_thumbnail`), so under a prefix every API call and asset request 404s.

## How

- **`launch.sh`**: new `--root-path` flag (or `ROOT_PATH` in `.env`), passed through to hypercorn's `--root-path`, which sets the ASGI `root_path`. Also a `--bind` flag (default unchanged at `0.0.0.0`) so the app can bind to `127.0.0.1` behind a same-host proxy.
- **`templates/index.html`**: exposes `request.root_path` as `window.APP_BASE`; all script/asset tags now use `url_for` (which already respects `root_path`).
- **`static/js/main.js`**: all root-absolute URLs prefixed with `APP_BASE` (empty string at root).
- **Templates**: remaining absolute `/static/...` references converted to `url_for`.
- **PWA manifests**: icon paths made relative, `start_url` made prefix-agnostic.
- **README**: new "Serving Under a URL Prefix" section with a sample nginx location block (including the SSE-related `proxy_buffering off` note).

## Behavior when not using a prefix

None of this changes default behavior: without `--root-path`, `APP_BASE` is `""` and all URLs render exactly as before.

## Tested

- Bare metal behind nginx at `/mousesearch/` on an Ultra.cc seedbox: search, thumbnails, SSE live status, settings, and PWA install all work under the prefix.
- Regression: launched without `--root-path` and verified rendered HTML and API paths are byte-identical to current behavior.
