### PR TITLE
include tid in MAM download links

### DIFF
--- a/app.py
+++ b/app.py
@@ -5189,8 +5189,12 @@ async def mam_search():
         # Now we decode HTML entities and fix formatting on the sorted list
         for item in ranked:
             # 1. Handle Download Links
-            if dl_hash := item.get('dl'):
-                item['download_link'] = base_dl_url + dl_hash
+            # MAM rejects the link with "Invalid download link: missing tid"
+            # unless the torrent id is passed as a query param.
+            dl_hash = item.get('dl')
+            torrent_id = item.get('id')
+            if dl_hash and torrent_id:
+                item['download_link'] = f"{base_dl_url}{dl_hash}?tid={torrent_id}"
             else:
                 item['download_link'] = ''
 


### PR DESCRIPTION
Fixes #54.

MAM stopped accepting the path-only download URL. Every `.torrent` fetch now comes back as:

```
400 Bad Request
Invalid download link: missing tid (torrent id)
```

Adding `?tid=<id>` to the link fixes it. The search JSON already returns `id` next to `dl`, so nothing extra needs to be fetched.

Checked against a live search, same torrent and session:

- `/tor/download.php/<dl>` → 400
- `/tor/download.php/<dl>?tid=<id>` → 200, valid torrent

`append_personal_freeleech_flag()` appends via query params, so it still works — the link just becomes `?tid=<id>&fl` instead of `?fl`.

I also made the link conditional on `id` being present. Without it the URL is guaranteed to 400, so an empty `download_link` seemed better than handing the UI one that can't work.
