### PR TITLE
Add rTorrent native SCGI unix-socket support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ TORRENT_CLIENT_TYPE=qbittorrent
 # For qbittorrent/deluge/transmission this is the WebUI URL.
 # For rtorrent this must be an XML-RPC endpoint, NOT the ruTorrent WebUI URL:
 #   self-hosted (Nginx/Apache scgi):  http://<host>/RPC2
+#   local rTorrent SCGI socket:       scgi+unix:///path/to/rpc.sock
 #   shared seedbox running ruTorrent: https://<seedbox address>/rutorrent/plugins/httprpc/action.php
 # See the "rTorrent / ruTorrent endpoints" section of the README.
 TORRENT_CLIENT_URL=http://qbittorrent:6767

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Which endpoint to use depends on how your setup exposes rTorrent:
 | Setup | `TORRENT_CLIENT_URL` |
 | :--- | :--- |
 | Self-hosted, XML-RPC proxied by Nginx/Apache (the usual `scgi_pass` / `mod_scgi` setup) | `http://<host>/RPC2` |
+| Local rTorrent SCGI socket (`network.scgi.open_local = /path/to/rpc.sock` in `.rtorrent.rc`) | `scgi+unix:///path/to/rpc.sock` |
 | Shared seedbox running ruTorrent, no direct XML-RPC exposed | `https://<seedbox address>/rutorrent/plugins/httprpc/action.php` |
 | Some providers give each user a named path | `https://<seedbox address>/<username>/rutorrent/plugins/httprpc/action.php` |
 
@@ -243,6 +244,7 @@ Most shared seedbox providers do **not** expose a direct XML-RPC interface, so t
 
 Notes:
 
+- With a `scgi+unix://` URL, MouseSearch talks to rTorrent's native SCGI listener directly — no webserver involved. Username/password and `RTORRENT_DIGEST_AUTH` do not apply, and the MouseSearch process needs read/write permission on the socket file.
 - If your provider's panel challenges you with HTTP Digest auth rather than Basic (common on seedboxes), also set `RTORRENT_DIGEST_AUTH=true`.
 - The `httprpc` plugin must be enabled in ruTorrent. If it is not in your ruTorrent plugin list, ask your provider to enable it or check whether they document a dedicated XML-RPC URL.
 - To confirm an endpoint before configuring MouseSearch:

--- a/clients/rtorrent.py
+++ b/clients/rtorrent.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import xml.etree.ElementTree as ET
 from urllib.parse import urlsplit, urlunsplit
@@ -41,6 +42,14 @@ class RTorrentClient(TorrentClient):
         self.username = config.get("TORRENT_CLIENT_USERNAME", "")
         self.password = config.get("TORRENT_CLIENT_PASSWORD", "")
         self.digest_auth = config.get("RTORRENT_DIGEST_AUTH", False)
+
+        # scgi+unix:///path/to/socket talks to rTorrent's native SCGI
+        # listener (network.scgi.open_local) directly over a unix socket
+        self.socket_path = None
+        if self.url.startswith("scgi+unix://"):
+            self.socket_path = unquote(self.url[len("scgi+unix://"):])
+            if not self.socket_path:
+                raise ValueError("scgi+unix:// TORRENT_CLIENT_URL is missing a socket path")
         
         # Standard ruTorrent label field is usually d.custom1
         self.label_attr = "d.custom1" 
@@ -74,6 +83,9 @@ class RTorrentClient(TorrentClient):
 <methodName>{method}</methodName>
 <params>{xml_params}</params>
 </methodCall>"""
+
+        if self.socket_path:
+            return await self._scgi_request(method, payload, sanitized_url)
 
         headers = {"Content-Type": "text/xml"}
         if self.digest_auth:
@@ -118,6 +130,47 @@ class RTorrentClient(TorrentClient):
                 str(e),
             )
             raise Exception(f"rTorrent connection failed: {e}")
+
+    async def _scgi_request(self, method: str, payload: str, sanitized_url: str):
+        """Speaks native SCGI to rTorrent's unix-socket listener."""
+        body = payload.encode("utf-8")
+        scgi_headers = b"CONTENT_LENGTH\x00" + str(len(body)).encode("ascii") + b"\x00SCGI\x001\x00"
+        request = str(len(scgi_headers)).encode("ascii") + b":" + scgi_headers + b"," + body
+
+        writer = None
+        try:
+            async def _exchange():
+                nonlocal writer
+                reader, writer = await asyncio.open_unix_connection(self.socket_path)
+                writer.write(request)
+                await writer.drain()
+                # rTorrent closes the SCGI connection after answering
+                return await reader.read()
+
+            data = await asyncio.wait_for(_exchange(), timeout=10.0)
+            text = data.decode("utf-8", errors="replace")
+            # Tolerate responders that prepend Status:/HTTP-style headers
+            xml_start = text.find("<?xml")
+            if xml_start > 0:
+                text = text[xml_start:]
+            return self._parse_xml_response(text)
+        except Exception as e:
+            logger.error(
+                "rTorrent XML-RPC request error: url=%s method=%s status=%s digest_auth=%s error=%s",
+                sanitized_url,
+                method,
+                "n/a",
+                bool(self.digest_auth),
+                str(e),
+            )
+            raise Exception(f"rTorrent connection failed: {e}")
+        finally:
+            if writer is not None:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except Exception:
+                    pass
 
     def _parse_xml_response(self, xml_str):
         """Parses the XML-RPC response."""

--- a/templates/modals/settings_offcanvas.html
+++ b/templates/modals/settings_offcanvas.html
@@ -69,6 +69,7 @@
               <div class="form-text small mb-3 d-none" id="rtorrent-url-hint">
                 rTorrent needs an <strong>XML-RPC endpoint</strong>, not the ruTorrent WebUI URL.
                 Self-hosted behind Nginx/Apache: <code>http://&lt;host&gt;/RPC2</code>.
+                Local rTorrent SCGI socket: <code>scgi+unix:///path/to/rpc.sock</code>.
                 Shared seedbox running ruTorrent:
                 <code>https://&lt;seedbox&gt;/rutorrent/plugins/httprpc/action.php</code>.
                 Some providers also require Digest auth (<code>RTORRENT_DIGEST_AUTH=true</code>).

--- a/tests/test_rtorrent_scgi.py
+++ b/tests/test_rtorrent_scgi.py
@@ -1,0 +1,114 @@
+import asyncio
+import os
+import tempfile
+import unittest
+
+from clients.rtorrent import RTorrentClient
+
+
+CANNED_VERSION_XML = (
+    b"<?xml version='1.0'?>\n"
+    b"<methodResponse><params><param><value><string>0.9.8</string></value></param>"
+    b"</params></methodResponse>"
+)
+
+
+async def _read_scgi_request(reader):
+    """Reads one SCGI request and returns (headers_dict, body_bytes)."""
+    length_digits = b""
+    while True:
+        ch = await reader.readexactly(1)
+        if ch == b":":
+            break
+        length_digits += ch
+    header_len = int(length_digits.decode("ascii"))
+    raw_headers = await reader.readexactly(header_len)
+    await reader.readexactly(1)  # trailing comma
+
+    headers = {}
+    parts = raw_headers.split(b"\x00")
+    for i in range(0, len(parts) - 1, 2):
+        headers[parts[i].decode("ascii")] = parts[i + 1].decode("ascii")
+
+    body = await reader.readexactly(int(headers["CONTENT_LENGTH"]))
+    return headers, body
+
+
+class SocketPathTests(unittest.TestCase):
+    def test_extracts_socket_path(self):
+        client = RTorrentClient({"TORRENT_CLIENT_URL": "scgi+unix:///rpc.sock"})
+        self.assertEqual(client.socket_path, "/rpc.sock")
+
+    def test_unquotes_socket_path(self):
+        client = RTorrentClient({"TORRENT_CLIENT_URL": "scgi+unix:///tmp/my%20sock"})
+        self.assertEqual(client.socket_path, "/tmp/my sock")
+
+    def test_http_url_leaves_socket_path_unset(self):
+        client = RTorrentClient({"TORRENT_CLIENT_URL": "http://localhost/RPC2"})
+        self.assertIsNone(client.socket_path)
+
+    def test_empty_socket_path_raises(self):
+        with self.assertRaises(ValueError):
+            RTorrentClient({"TORRENT_CLIENT_URL": "scgi+unix://"})
+
+
+class ScgiExchangeTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="mousesearch-scgi-test-")
+        self.sock_path = os.path.join(self.tmpdir, "rpc.sock")
+
+    def tearDown(self):
+        if os.path.exists(self.sock_path):
+            os.unlink(self.sock_path)
+        os.rmdir(self.tmpdir)
+
+    def _run_with_server(self, response_bytes, captured):
+        client = RTorrentClient({"TORRENT_CLIENT_URL": f"scgi+unix://{self.sock_path}"})
+
+        async def handler(reader, writer):
+            captured["request"] = await _read_scgi_request(reader)
+            writer.write(response_bytes)
+            await writer.drain()
+            writer.close()
+
+        async def run():
+            server = await asyncio.start_unix_server(handler, path=self.sock_path)
+            async with server:
+                logged_in = await client.login()
+                version = await client.get_api_version()
+            return logged_in, version
+
+        return asyncio.run(run())
+
+    def test_round_trip_and_framing(self):
+        captured = {}
+        logged_in, version = self._run_with_server(CANNED_VERSION_XML, captured)
+
+        self.assertTrue(logged_in)
+        self.assertEqual(version, "0.9.8")
+
+        headers, body = captured["request"]
+        self.assertEqual(headers.get("SCGI"), "1")
+        self.assertEqual(int(headers["CONTENT_LENGTH"]), len(body))
+        self.assertIn(b"<methodName>system.client_version</methodName>", body)
+
+    def test_response_with_header_preamble(self):
+        captured = {}
+        response = b"Status: 200 OK\r\nContent-Type: text/xml\r\n\r\n" + CANNED_VERSION_XML
+        logged_in, version = self._run_with_server(response, captured)
+
+        self.assertTrue(logged_in)
+        self.assertEqual(version, "0.9.8")
+
+    def test_missing_socket_login_fails(self):
+        missing = os.path.join(self.tmpdir, "does-not-exist.sock")
+        client = RTorrentClient({"TORRENT_CLIENT_URL": f"scgi+unix://{missing}"})
+
+        with self.assertLogs("clients.rtorrent", level="ERROR"):
+            logged_in = asyncio.run(client.login())
+
+        self.assertFalse(logged_in)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Allow TORRENT_CLIENT_URL=scgi+unix:///path/to/rpc.sock to talk directly to rTorrent's native SCGI listener (network.scgi.open_local), which previously failed with "Request URL is missing an 'http://' protocol".

The scgi+unix transport frames the existing XML-RPC payload as a SCGI netstring over asyncio.open_unix_connection with the same 10s timeout, tolerates Status:/HTTP-style response preambles, and logs/raises in the existing format. HTTP endpoint behavior is unchanged.