### PR TITLE
Fix web asset permissions for rootless containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,10 @@ COPY version.txt ./version.txt
 COPY hashing.py ./
 
 COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+# Keep web assets readable when the build context has a restrictive umask.
+# This also supports rootless starts that intentionally bypass the entrypoint.
+RUN chmod -R a+rX /app/templates /app/static \
+    && chmod +x /app/entrypoint.sh
 
 # Make port 5000 available to the world outside this container
 EXPOSE 5000


### PR DESCRIPTION
## Summary

- normalize copied template and static asset permissions during the image build
- keep assets readable and directories traversable for rootless processes that bypass the entrypoint
- preserve existing executable bits with `a+rX`

Closes #74.

## Testing

- `python -m unittest discover -s tests -v` (16 tests passed)
- `sh -n entrypoint.sh`
- `bash -n tools/buildImage.sh`
- simulated a `0600` `wedge_purchase.html` build-context file and verified the normalization produces `0644`
- `git diff --check`

A full Docker image build was not run because the test environment does not provide a Docker daemon.